### PR TITLE
Make the plugin not apply to any .txt file [Recommended version]

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ PyCharm, and other products if the Python plugin is installed:
 
 ## TODO
 
-* Distinguish a plain text file from file requirements.txt
 * Support all relations
 * Opening local source code
 * Code completion

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
                   order="first"
                   name="requirements.txt"
                   fileNames="requirements.txt"
-                  patterns="*.txt"/>
+                  patterns=""/>
         <localInspection language="requirements.txt"
                          shortName="ReferenceExistsInspection"
                          suppressId="Requirements"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,8 +15,8 @@
                   language="requirements.txt"
                   order="first"
                   name="requirements.txt"
-                  fileNames="requirements.txt"
-                  patterns=""/>
+                  fileNames="requirements.txt;constraints.txt"
+                  patterns="*requirements.txt;*constraints.txt"/>
         <localInspection language="requirements.txt"
                          shortName="ReferenceExistsInspection"
                          suppressId="Requirements"


### PR DESCRIPTION
This is a pull request that will remove the *.txt file name matching and replace it with matching for common names for files that use this syntax (*requirements.txt and *constraints.txt).

I've provided two pull requests, either of which will solve the problem of documentation .txt files getting red error markings and uneven text coloring as a result of requirements language syntax highlighting being applied to it. This is my recommended alternative, but I've provided an alternative in case you don't like the new string matching.

For more details, please see the commit messages.