### PR TITLE
Make the plugin not apply to any .txt file [Alternative, without new string matches]

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ PyCharm, and other products if the Python plugin is installed:
 
 ## TODO
 
-* Distinguish a plain text file from file requirements.txt
 * Support all relations
 * Opening local source code
 * Code completion

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
                   order="first"
                   name="requirements.txt"
                   fileNames="requirements.txt"
-                  patterns="*.txt"/>
+                  patterns=""/>
         <localInspection language="requirements.txt"
                          shortName="ReferenceExistsInspection"
                          suppressId="Requirements"


### PR DESCRIPTION
This is a pull request that will remove the *.txt file matching, causing the plugin to only apply to files with the exact name requirements.txt.

I've provided two pull requests, either of which will solve the problem of documentation .txt files getting red error markings and uneven text coloring as a result of requirements language syntax highlighting being applied to it. The other one is my recommended alternative, which includes new string matching for other common names for files that use this syntax.

For more details, please see the commit messages.