### PR TITLE
use builtin python requirement matcher, support all relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,5 @@ PyCharm, and other products if the Python plugin is installed:
 ## TODO
 
 * Distinguish a plain text file from file requirements.txt
-* Support all relations
 * Opening local source code
 * Code completion

--- a/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
+++ b/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
@@ -50,7 +50,7 @@ class InstalledPackageInspection : LocalInspectionTool() {
                                 "latest: ${latest?.presentableText ?: "<unknown>"}"
 
 
-                if (requirement != null && (installed == null || !installed.matches(requirement))) {
+                if (requirement != null && installed?.matches(requirement) != true) {
                     val message = "'${requirement.presentableText}' " +
                             "is not installed ($versionsRepresentation)"
                     holder.registerProblem(element,

--- a/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
+++ b/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
@@ -58,7 +58,8 @@ class InstalledPackageInspection : LocalInspectionTool() {
                             InstallPackageQuickFix(element,
                                     "Install '${requirement.presentableText}' " +
                                             "($versionsRepresentation)",
-                                    requirement))
+                                    requirement,
+                                    false))
 
                 } else if (latest != null && installed != null && PyPackageVersionNormalizer.normalize(installed.version) < latest) {
                     val message = "'$packageName' version '${installed.version}' " +
@@ -69,7 +70,8 @@ class InstalledPackageInspection : LocalInspectionTool() {
                                     "Install '$packageName' " +
                                             "version '${latest.presentableText}' " +
                                             "($versionsRepresentation)",
-                                    PyRequirementParser.fromLine("$packageName==${latest.presentableText}")!!))
+                                    PyRequirementParser.fromLine("$packageName==${latest.presentableText}")!!,
+                                    true))
                 }
             }
 

--- a/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
+++ b/src/main/kotlin/ru/meanmail/codeInspection/InstalledPackageInspection.kt
@@ -59,9 +59,8 @@ class InstalledPackageInspection : LocalInspectionTool() {
                                     "Install '${requirement.presentableText}' " +
                                             "($versionsRepresentation)",
                                     requirement))
-                }
 
-                if (latest != null && installed != null && PyPackageVersionNormalizer.normalize(installed.version) < latest) {
+                } else if (latest != null && installed != null && PyPackageVersionNormalizer.normalize(installed.version) < latest) {
                     val message = "'$packageName' version '${installed.version}' " +
                             "is outdated ($versionsRepresentation)"
                     holder.registerProblem(element,

--- a/src/main/kotlin/ru/meanmail/quickfix/InstallPackageQuickFix.kt
+++ b/src/main/kotlin/ru/meanmail/quickfix/InstallPackageQuickFix.kt
@@ -6,12 +6,13 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.util.FileContentUtil
+import com.jetbrains.python.packaging.PyRequirement
 import ru.meanmail.installPackage
 import ru.meanmail.psi.NameReq
 
 class InstallPackageQuickFix(element: NameReq,
                              private val description: String,
-                             private val version: String) : LocalQuickFixOnPsiElement(element) {
+                             private val requirement: PyRequirement) : LocalQuickFixOnPsiElement(element) {
     override fun getText(): String {
         return description
     }
@@ -21,14 +22,11 @@ class InstallPackageQuickFix(element: NameReq,
                         endElement: PsiElement) {
         val element = (startElement as? NameReq) ?: return
         val packageName = element.name.text ?: return
-        val versionOne = element.versionspec?.versionMany?.versionOneList?.get(0) ?: return
-        val versionCmp = versionOne.versionCmp.text ?: "=="
 
-        installPackage(project, packageName, version, versionCmp) {
+        installPackage(project, packageName, requirement) {
             val application = ApplicationManager.getApplication()
             application.invokeLater {
                 application.runWriteAction {
-                    versionOne.setVersion(version)
                     val virtualFile = element.containingFile.virtualFile
                     FileContentUtil.reparseFiles(project, listOf(virtualFile),
                             true)


### PR DESCRIPTION
Fixes #10

Hi, I converted the installed package inspection to use the requirement parser and matcher from the Python plugin. This automatically supports all relations (`==`, `>=`, `<`, `~=`...), and even `package==1.*` format.

I had to change some texts for them to make sense (attached a few screenshots below).

Let me know if this helps or if something needs to change.


Before:
![Screenshot from 2020-08-05 19-56-22](https://user-images.githubusercontent.com/20871882/89447163-d725eb80-d755-11ea-8ec1-962516db0ca0.png)


After:

![Screenshot from 2020-08-05 19-46-35](https://user-images.githubusercontent.com/20871882/89446312-a8f3dc00-d754-11ea-8f1c-1300681f201a.png)

![Screenshot from 2020-08-05 19-46-40](https://user-images.githubusercontent.com/20871882/89446299-a42f2800-d754-11ea-86b7-e274d35f48a8.png)

![Screenshot from 2020-08-05 19-50-04](https://user-images.githubusercontent.com/20871882/89446516-e9ebf080-d754-11ea-908c-452eb6d7edc2.png)
