### PR TITLE
Fix typo in constraints association

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
                   language="requirements.txt"
                   order="first"
                   name="requirements.txt"
-                  fileNames="requirements.txt;constrains.txt"
+                  fileNames="requirements.txt;constraints.txt"
                   patterns="*requirements*.txt;*.txt"/>
         <fileTypeDetector implementation="ru.meanmail.fileTypes.RequirementsFileTypeDetector"
                           order="first"/>


### PR DESCRIPTION
Fixing a small typo in the association metadata, so we automatically associate `constraints.txt` with the plugin rather than `constrains.txt`.