### PR TITLE
Fix for "Package not found" error for package that exists

### DIFF
--- a/src/main/kotlin/ru/meanmail/pypi/serializers/FileInfo.kt
+++ b/src/main/kotlin/ru/meanmail/pypi/serializers/FileInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class FileInfo(
-    val comment_text: String = "",
+    val comment_text: String? = null,
     val digests: Map<String, String> = mapOf(),
     val downloads: Int = -1,
     val filename: String,


### PR DESCRIPTION
Need to exclude null property value when serialization gets executed.