### PR TITLE
fix: coerce JSON returned by PyPi to allow empty project comment

### DIFF
--- a/src/main/kotlin/ru/meanmail/pypi/PyPi.kt
+++ b/src/main/kotlin/ru/meanmail/pypi/PyPi.kt
@@ -28,7 +28,7 @@ import javax.swing.text.html.parser.ParserDelegator
 
 const val PYPI_URL = "https://pypi.org"
 val EXPIRATION_TIMEOUT: Duration = Duration.ofMinutes(5)
-val format = Json { ignoreUnknownKeys = true }
+val format = Json { ignoreUnknownKeys = true; coerceInputValues = true }
 val cache = mutableMapOf<String, Pair<PackageInfo, Instant>>()
 
 


### PR DESCRIPTION
closes #93 

If the PyPI package comment is empty, Requirements will throw an exception because it cannot decode a null value.

My change would force ``null`` values to be decoded as its default value.
I could not find any new bugs introduced by my change, but I cannot say for sure.